### PR TITLE
Fix for calendar

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ layout: default
 
 <!--google cal here-->
 
-<!--<iframe src="https://www.google.com/calendar/embed?src=drakemtb%40gmail.com&ctz=America/Los_Angeles" style="border: 0" width="100%" height="500px" frameborder="0" scrolling="no"></iframe>-->
+<iframe src="https://www.google.com/calendar/embed?src=drakemtb%40gmail.com&ctz=America/Los_Angeles" style="border: 0" width="100%" height="500px" frameborder="0" scrolling="no"></iframe>
 
 <!--who we are -->
 <h1>Welcome to the online home of the Drake Pirates MTB Team</h1>
@@ -37,7 +37,7 @@ layout: default
 				  {% endfor %}
 				</div>
 			</div>
-			<iframe src="https://www.google.com/calendar/embed?src=drakemtb%40gmail.com&ctz=America/Los_Angeles" style="border: 0" width="100%" height="500px" frameborder="0" scrolling="no"></iframe>
+			<br />
+			<h3 style="text-align:center;">Follow DrakeMTB on Social Media!</h3>
 
 <script src="//code.jquery.com/jquery-latest.min.js"></script>
-<script src="//unslider.com/unslider.min.js"></script>


### PR DESCRIPTION
As you know, the google calendar was what was keeping the footer from wrapping itself over the blog and our story section.  To fix this, I added a self contained element which prevents the footer from wrapping over the blog, which has no set length.  To make it a little less obvious that this was a fix, I let the `<h3>` tag say: “Follow DrakeMTB on Social Media!”.
